### PR TITLE
Updates to the new MongoHQ addon name

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -5,7 +5,7 @@ BUILD_DIR=$1
 cat <<-YAML
 ---
 addons:
-  - mongohq:free
+  - mongohq:sandbox
 config_vars:
 default_process_types:
   web: PATH=.meteor/local/usr/bin:.meteor/local/usr/lib/meteor/bin:bin:/usr/local/bin:/usr/bin:/bin NODE_PATH=.meteor/local/usr/lib/meteor/lib/node_modules MONGO_URL=\$MONGOHQ_URL node .meteor/local/build/main.js


### PR DESCRIPTION
MongoHQ's free version changed from "mongohq:free" to "mongohq:sandbox" .  This was breaking your build file.

It's a one word change.

Thanks!
