### PR TITLE
Failing to start on Heroku due to new Meteor v0.8.18 dependency (critical)

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -8,5 +8,5 @@ addons:
   - mongohq:sandbox
 config_vars:
 default_process_types:
-  web: PATH=.meteor/local/usr/bin:.meteor/local/usr/lib/meteor/bin:bin:/usr/local/bin:/usr/bin:/bin NODE_PATH=.meteor/local/usr/lib/meteor/lib/node_modules MONGO_URL=\$MONGOHQ_URL node .meteor/local/build/main.js
+  web: PATH=.meteor/local/usr/bin:.meteor/local/usr/lib/meteor/bin:bin:/usr/local/bin:/usr/bin:/bin NODE_PATH=.meteor/local/usr/lib/meteor/lib/node_modules MONGO_URL=\$MONGOHQ_URL .meteor/local/usr/lib/meteor/bin/node .meteor/local/build/main.js
 YAML


### PR DESCRIPTION
(see Issue #9)

In short, the current buildpack is using the Heroku-provided/system node installation.

A recent commit to Meteor causes it to require v0.8.18 of the NodeJS binary.

As there is no package.json (and providing one breaks for an unknown reason), it is not possible to specify which version of NodeJS Heroku uses.

This patch uses the meteor-bundled NodeJS binary instead.
