### PR TITLE
Meteor 1.2 requires Node v0.10.40 or later.

### DIFF
--- a/bin/compile_node
+++ b/bin/compile_node
@@ -34,7 +34,7 @@ export_env_dir $env_dir
 # What's the requested semver range for node?
 #node_engine=$(package_json ".engines.node")
 # Node version is locked for now: newer ones don't work with Meteor.
-node_engine="0.10.36"
+node_engine="0.10.40"
 node_previous=$(file_contents "$cache_dir/node/node-version")
 
 # What's the requested semver range for npm?


### PR DESCRIPTION
I updated my meteor app to meteor 1.2 and my heroku build broke with the following error:

```
2015-09-22 02:39:39.949718+00:00 heroku web.1 - - Starting process with command `node build/bundle/main.js`
2015-09-22 02:39:41.986623+00:00 app web.1 - - Meteor requires Node v0.10.40 or later.
2015-09-22 02:39:42.746513+00:00 heroku web.1 - - Process exited with status 1
```

Updating build to use Node v0.10.40 should fix this, but might break build for anyone on older versions of Meteor.
