### PR TITLE
update to node 0.10.41 for Meteor 1.3

### DIFF
--- a/bin/compile_node
+++ b/bin/compile_node
@@ -34,7 +34,7 @@ export_env_dir $env_dir
 # What's the requested semver range for node?
 #node_engine=$(package_json ".engines.node")
 # Node version is locked for now: newer ones don't work with Meteor.
-node_engine="0.10.40"
+node_engine="0.10.41"
 node_previous=$(file_contents "$cache_dir/node/node-version")
 
 # What's the requested semver range for npm?


### PR DESCRIPTION
When updating to Meteor 1.3, Min version of node required is 0.10.41.

A git push to heroku with a Meteor 1.3 project will not spin up on Heroku.

I don't know if this is all that is required, but it worked.
