### PR TITLE
Updated node engine. Meteor 1.3 requires Node v0.10.41 or later

### DIFF
--- a/bin/compile_node
+++ b/bin/compile_node
@@ -34,7 +34,7 @@ export_env_dir $env_dir
 # What's the requested semver range for node?
 #node_engine=$(package_json ".engines.node")
 # Node version is locked for now: newer ones don't work with Meteor.
-node_engine="0.10.40"
+node_engine="0.10.41"
 node_previous=$(file_contents "$cache_dir/node/node-version")
 
 # What's the requested semver range for npm?


### PR DESCRIPTION
I was unable to use this buildpack for heroku as-was for a Meteor 1.3 app.  Bumping the Node version solved the issue.  Perhaps make separate branches for the different Node versions, or choose the latest version dynamically a la https://github.com/AdmitHub/meteor-buildpack-horse/blob/master/bin/compile#L92?  
