### PR TITLE
Fix file direcotry in compile_node 

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -19,5 +19,5 @@ source $bp_dir/bin/common.sh
 
 
 # Install node first, as a dependency, then install meteor & build app
-$bp_dir/bin/compile_node "$1" "$2"
+$bp_dir/bin/compile_node "$1/app_src" "$2"
 $bp_dir/bin/compile_meteor "$1" "$2"

--- a/bin/compile
+++ b/bin/compile
@@ -19,5 +19,5 @@ source $bp_dir/bin/common.sh
 
 
 # Install node first, as a dependency, then install meteor & build app
-$bp_dir/bin/compile_node "$1/app_src" "$2"
+$bp_dir/bin/compile_node "$1" "$2"
 $bp_dir/bin/compile_meteor "$1" "$2"

--- a/bin/compile_node
+++ b/bin/compile_node
@@ -34,7 +34,7 @@ export_env_dir $env_dir
 # What's the requested semver range for node?
 #node_engine=$(package_json ".engines.node")
 # Node version is locked for now: newer ones don't work with Meteor.
-node_engine="0.10.40"
+node_engine="0.10.41"
 node_previous=$(file_contents "$cache_dir/node/node-version")
 
 # What's the requested semver range for npm?

--- a/bin/compile_node
+++ b/bin/compile_node
@@ -11,6 +11,7 @@ set -o pipefail   # don't ignore exit codes when piping output
 build_dir=$1
 cache_dir=$2
 env_dir=$3
+app_source=$build_dir/app_src
 bp_dir=$(cd $(dirname $0); cd ..; pwd)
 heroku_dir=$build_dir/.heroku
 mkdir -p $heroku_dir/node
@@ -42,16 +43,16 @@ npm_engine=$(package_json ".engines.npm")
 npm_previous=$(file_contents "$cache_dir/node/npm-version")
 
 # How does this app start?
-if test -f $build_dir/Procfile; then start_method="Procfile"
+if test -f $app_source/Procfile; then start_method="Procfile"
 elif [[ $(package_json ".scripts.start") != "" ]]; then start_method="npm start"
-elif [ -f $build_dir/server.js ]; then start_method="server.js"
+elif [ -f $app_source/server.js ]; then start_method="server.js"
 else start_method=""
 fi
 
 # What's the source-of-truth for node_modules?
-if test -d $build_dir/node_modules; then modules_source="prebuilt"
-elif test -f $build_dir/npm-shrinkwrap.json; then modules_source="npm-shrinkwrap.json"
-elif test -f $build_dir/package.json; then modules_source="package.json"
+if test -d $app_source/node_modules; then modules_source="prebuilt"
+elif test -f $app_source/npm-shrinkwrap.json; then modules_source="npm-shrinkwrap.json"
+elif test -f $app_source/package.json; then modules_source="package.json"
 else modules_source=""
 fi
 
@@ -105,7 +106,7 @@ if [ "$npm_engine" != "" ]; then
 fi
 
 # Run subsequent commands from the build directory
-cd $build_dir
+cd $app_source
 
 ####### Build the project's dependencies
 
@@ -134,20 +135,20 @@ elif [ $modules_source == "prebuilt" ]; then
   info "Rebuilding any native modules for this architecture"
   npm rebuild 2>&1 | indent
   info "Installing any new modules"
-  npm install --quiet --userconfig $build_dir/.npmrc 2>&1 | indent
+  npm install --quiet --userconfig $app_source/.npmrc 2>&1 | indent
 
 elif $use_cache; then
   info "Restoring node modules from cache"
-  cp -r $cache_dir/node/node_modules $build_dir/
+  cp -r $cache_dir/node/node_modules $app_source/
   info "Pruning unused dependencies"
   npm prune 2>&1 | indent
   info "Installing any new modules"
-  npm install --quiet --userconfig $build_dir/.npmrc 2>&1 | indent
+  npm install --quiet --userconfig $app_source/.npmrc 2>&1 | indent
 
 else
   info "Installing node modules"
-  touch $build_dir/.npmrc
-  npm install --quiet --userconfig $build_dir/.npmrc 2>&1 | indent
+  touch $app_source/.npmrc
+  npm install --quiet --userconfig $app_source/.npmrc 2>&1 | indent
 fi
 
 ####### Create a Procfile if possible
@@ -158,10 +159,10 @@ if [ "$start_method" == "Procfile" ]; then
   info "Found Procfile"
 elif [ "$start_method" == "npm start" ]; then
   info "No Procfile; Adding 'web: npm start' to new Procfile"
-  echo "web: npm start" > $build_dir/Procfile
+  echo "web: npm start" > $app_source/Procfile
 elif [ "$start_method" == "server.js" ]; then
   info "No Procfile; Adding 'web: node server.js' to new Procfile"
-  echo "web: node server.js" > $build_dir/Procfile
+  echo "web: node server.js" > $app_source/Procfile
 fi
 
 ####### Create the runtime environment (profile.d)
@@ -175,8 +176,8 @@ echo "export PATH=\"\$HOME/.heroku/node/bin:\$HOME/bin:\$HOME/node_modules/.bin:
 echo "export NODE_HOME=\"\$HOME/.heroku/node\"" >> $build_dir/.profile.d/nodejs.sh
 
 info "Exporting binary paths"
-echo "export PATH=\"$build_dir/.heroku/node/bin:$build_dir/node_modules/.bin:\$PATH\"" > $bp_dir/export
-echo "export NODE_HOME=\"$build_dir/.heroku/node\"" >> $bp_dir/export
+echo "export PATH=\"$heroku_dir/node/bin:$build_dir/node_modules/.bin:\$PATH\"" > $bp_dir/export
+echo "export NODE_HOME=\"$heroku_dir/node\"" >> $bp_dir/export
 
 ####### Clean up
 
@@ -198,9 +199,9 @@ mkdir -p $cache_dir/node
 echo $node_engine > $cache_dir/node/node-version
 echo $npm_engine > $cache_dir/node/npm-version
 
-if test -d $build_dir/node_modules; then
+if test -d $app_source/node_modules; then
   info "Caching node_modules for future builds"
-  cp -r $build_dir/node_modules $cache_dir/node
+  cp -r $app_source/node_modules $cache_dir/node
 fi
 
 # Show the final dependency tree


### PR DESCRIPTION
Since all files are moved into app_src, compile_node is not able to find modules source with the original build directory.
This may also fix #64 
